### PR TITLE
Fix for content type mismatch with webhook lambda

### DIFF
--- a/bin/out
+++ b/bin/out
@@ -51,7 +51,7 @@ async function processWebhook(source, params) {
 
     const config = {
         'url': url,
-        'content_type': 'json'
+        'content_type': 'form'
     };
     
     const body = {


### PR DESCRIPTION
<!--
    Make sure your pull request is ready:
    - Read the contributing guidelines: https://github.com/homedepot/github-webhook-resource/blob/master/CONTRIBUTING.md
    - Include tests for this change
    - Update documentation to reflect this change (if appropriate)
-->

**What is the purpose of this pull request?**
<!-- Remove the empty space and paste an "X" inside the [] next to the correct item. -->
- [x] Bug fix
- [ ] Documentation update
- [ ] Code cleanup
- [ ] New feature
- [ ] Other (please explain):

<!-- If your change addresses an issue, please paste the issue number below. -->
**Addresses #**


**What changes did you make? (Give a brief overview)**


**Is there anything specific you would like reviewers to focus on?**
